### PR TITLE
chore: release v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/near/near-gas/compare/v0.2.4...v0.2.5) - 2023-10-23
+
+### Other
+- Update README.md
+- Fixed typo and added badges in README.md ([#12](https://github.com/near/near-gas/pull/12))
+
 ## [0.2.4](https://github.com/near/near-gas/compare/v0.2.3...v0.2.4) - 2023-10-22
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-gas"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 authors = ["Serhieiev Ivan <serhieievivan6@gmail.com>", "Vlad Frolov <frolvlad@gmail.com>"]
 repository = "https://github.com/near/near-gas"


### PR DESCRIPTION
## 🤖 New release
* `near-gas`: 0.2.4 -> 0.2.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.5](https://github.com/near/near-gas/compare/v0.2.4...v0.2.5) - 2023-10-23

### Other
- Update README.md
- Fixed typo and added badges in README.md ([#12](https://github.com/near/near-gas/pull/12))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).