### PR TITLE
chore: release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/near/near-gas-rs/compare/v0.2.5...v0.2.6) - 2024-08-12
+
+### Other
+- Extended the range of supported interactive-clap versions ([#15](https://github.com/near/near-gas-rs/pull/15))
+
 ## [0.2.5](https://github.com/near/near-gas/compare/v0.2.4...v0.2.5) - 2023-10-23
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-gas"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 authors = [
     "Serhieiev Ivan <serhieievivan6@gmail.com>",


### PR DESCRIPTION
## 🤖 New release
* `near-gas`: 0.2.5 -> 0.2.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.6](https://github.com/near/near-gas-rs/compare/v0.2.5...v0.2.6) - 2024-08-12

### Other
- Extended the range of supported interactive-clap versions ([#15](https://github.com/near/near-gas-rs/pull/15))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).